### PR TITLE
added Google cached webpages

### DIFF
--- a/src/assets/products/google.json
+++ b/src/assets/products/google.json
@@ -2554,5 +2554,14 @@
 		"description": "Pixel Pass was subscription designed to let customers pay for a Pixel phone in monthly installments while also getting access to Google’s premium subscription services such as Google One cloud storage, YouTube Premium, and Google Play Pass",
 		"type": "service",
 		"company": "google"
+	},
+	{
+		"name": "Google cached webpages",
+		"dateOpen": "1998-09-04",
+		"dateClose": "2024-02-01",
+		"link": "https://twitter.com/searchliaison/status/1753156161509916873",
+		"description": "Google has stopped keeping a backup of the internet by removing the 'cached' links feature on Google Search. The decision was made due to improved website loading reliability over time.",
+		"type": "service",
+		"company": "google"
 	}
 ]

--- a/src/assets/products/google.json
+++ b/src/assets/products/google.json
@@ -2559,7 +2559,7 @@
 		"name": "Google cached webpages",
 		"dateOpen": "1998-09-04",
 		"dateClose": "2024-02-01",
-		"link": "https://twitter.com/searchliaison/status/1753156161509916873",
+		"link": "https://en.wikipedia.org/wiki/Search_engine_cache",
 		"description": "Google has stopped keeping a backup of the internet by removing the 'cached' links feature on Google Search. The decision was made due to improved website loading reliability over time.",
 		"type": "service",
 		"company": "google"


### PR DESCRIPTION
Added the ending of Google caching webpages.

Sadly, I was not able to find when they started to cache webpages, only that it is one of the oldest feature of google. So I toke the freedom and toke the founding date of Google.

Sources, that I used/searched:
- https://arstechnica.com/gadgets/2024/02/google-search-kills-off-cached-webpages/
- https://www.heise.de/news/Eine-der-aeltesten-Funktionen-Google-stampft-den-Google-Cache-ein-9618032.html
- https://www.theregister.com/2024/02/05/google_cache_flushed/
- https://www.theverge.com/2024/2/2/24058985/google-search-cache-feature-discontinued
- https://www.semrush.com/blog/google-cached-pages/
- https://en.wikipedia.org/wiki/Search_engine_cache
- https://en.wikipedia.org/wiki/Google