### PR TITLE
Add People Cards to google.json

### DIFF
--- a/src/assets/products/google.json
+++ b/src/assets/products/google.json
@@ -2554,5 +2554,15 @@
 		"description": "Pixel Pass was subscription designed to let customers pay for a Pixel phone in monthly installments while also getting access to Google’s premium subscription services such as Google One cloud storage, YouTube Premium, and Google Play Pass",
 		"type": "service",
 		"company": "google"
+	},
+	{
+		"name": "People Cards",
+		"dateOpen": "2020-08-11",
+		"dateClose": "2024-04-07",
+		"link": "https://odishatv.in/news/technology/google-to-remove-people-cards-from-search-engine-229662",
+		"description": "People Cards was a crowdsourced knowledge base to enhance search results.",
+		"type": "service",
+		"company": "google"
+
 	}
 ]


### PR DESCRIPTION
based on the email I received yesterday:

![image](https://github.com/edvinlinden/killedby.tech/assets/48585950/420b5849-51af-4508-8b0d-e155efd1b6b9)


Only one news site seems to have the info as of now: https://odishatv.in/news/technology/google-to-remove-people-cards-from-search-engine-229662

Date open is taken from the publishing date of the blog post by google - https://blog.google/intl/en-in/products/explore-communicate/introducing-people-cards-virtual/

Date close is taken from the email I received.